### PR TITLE
Fix for gawk no longer being in the base container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ LABEL com.suse.release-stage="prototype"
 # endlabelprefix
 
 RUN zypper install --no-recommends -y \
+              gawk \
               iptables \
               libvirt-daemon-qemu \
               nftables \


### PR DESCRIPTION
 - Fixes #7, 
 - With awk missing from the container, this caused installation to happen in the wrong directory, resulting in read-only filesystem errors
